### PR TITLE
Add Collection overloads to LogicBindings

### DIFF
--- a/src/main/java/eu/lestard/advanced_bindings/api/LogicBindings.java
+++ b/src/main/java/eu/lestard/advanced_bindings/api/LogicBindings.java
@@ -45,10 +45,8 @@ public class LogicBindings {
     @SafeVarargs
     public static BooleanBinding and(ObservableValue<Boolean>...values) {
         return Bindings.createBooleanBinding(
-            ()-> !Arrays.stream(values)
-                .filter(observable -> !observable.getValue())
-                .findAny()
-                .isPresent(), values);
+            ()-> Arrays.stream(values)
+                .allMatch(observable -> observable.getValue()), values);
     }
 
     /**
@@ -81,9 +79,7 @@ public class LogicBindings {
     @SafeVarargs
     public static BooleanBinding or(ObservableValue<Boolean>...values) {
         return Bindings.createBooleanBinding(()-> Arrays.stream(values)
-            .filter(ObservableValue::getValue)
-            .findAny()
-            .isPresent(), values);
+            .anyMatch(observable -> observable.getValue()), values);
     }
 
     /**

--- a/src/main/java/eu/lestard/advanced_bindings/api/LogicBindings.java
+++ b/src/main/java/eu/lestard/advanced_bindings/api/LogicBindings.java
@@ -26,6 +26,7 @@ import javafx.beans.binding.BooleanBinding;
 import javafx.beans.value.ObservableValue;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 
 public class LogicBindings {
@@ -51,6 +52,22 @@ public class LogicBindings {
     }
 
     /**
+     * A boolean binding that is `true` only when all dependent observable boolean values
+     * are `true`.
+     *
+     * This can be useful in cases where the
+     * {@link Bindings#and(javafx.beans.value.ObservableBooleanValue, javafx.beans.value.ObservableBooleanValue)}
+     * with 2 arguments isn't enough.
+     *
+     * @param values collection of observable boolean values that are used for the binding
+     * @return the boolean binding
+     */
+    @SuppressWarnings("unchecked")
+    public static BooleanBinding and(Collection<ObservableValue<Boolean>> values) {
+        return and(values.toArray(new ObservableValue[0]));
+    }
+
+    /**
      * A boolean binding that is only `true` when at leased one of the dependent observable boolean values
      * are `true`.
      *
@@ -67,5 +84,21 @@ public class LogicBindings {
             .filter(ObservableValue::getValue)
             .findAny()
             .isPresent(), values);
+    }
+
+    /**
+     * A boolean binding that is only `true` when at leased one of the dependent observable boolean values
+     * are `true`.
+     *
+     * This can be useful in cases where the
+     * {@link Bindings#or(javafx.beans.value.ObservableBooleanValue, javafx.beans.value.ObservableBooleanValue)}
+     * with 2 arguments isn't enough.
+     *
+     * @param values collection of observable boolean values that are used for the binding
+     * @return the boolean binding
+     */
+    @SuppressWarnings("unchecked")
+    public static BooleanBinding or(Collection<ObservableValue<Boolean>> values) {
+        return or(values.toArray(new ObservableValue[0]));
     }
 }


### PR DESCRIPTION
Title says it all. Closes #5.

I also changed the `filter.findAny.isPresent` chains to `allMatch` and `anyMatch` for readability and (minor) performance improvement.